### PR TITLE
feat: add filename_style configuration option

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -86,6 +86,20 @@ The following [config options] are available:
   config.file_suffix = 'Api.ts'
   ```
 
+### `filename_style`
+  
+  Allows to configure filename style for the generated files. You can modify it if you want to use a different filename convention. 
+  
+  `:kebab` - Converts the controller name to kebab-case and appends the file suffix in lowercase.
+  
+  `:camel` - Converts the controller name to CamelCase and appends the file suffix.
+
+  __Default__: `:camel`
+
+  ```ruby
+  config.filename_style = :kebab
+  ```
+
 ### `helper_mappings`
   
   Defines how to obtain a path helper name from the name of a route (controller action).

--- a/js_from_routes/lib/js_from_routes/generator.rb
+++ b/js_from_routes/lib/js_from_routes/generator.rb
@@ -47,7 +47,14 @@ module JsFromRoutes
 
     # Internal: The base name of the JS file to be written.
     def basename
-      "#{@controller.camelize}#{@config.file_suffix}".tr_s(":", "/")
+      case @config.filename_style
+      when :kebab
+        "#{@controller.underscore.tr("_", "-")}-#{@config.file_suffix.downcase}"
+      when :camel
+        "#{@controller.camelize(:upper).tr_s(":", "/")}#{@config.file_suffix}"
+      else
+        "#{@controller.camelize(:upper).tr_s(":", "/")}#{@config.file_suffix}"
+      end
     end
   end
 
@@ -129,7 +136,7 @@ module JsFromRoutes
   class Configuration
     attr_accessor :all_helpers_file, :client_library, :export_if, :file_suffix,
       :helper_mappings, :output_folder, :template_path,
-      :template_all_path, :template_index_path
+      :template_all_path, :template_index_path, :filename_style
 
     def initialize(root)
       dir = %w[frontend packs javascript assets].find { |dir| root.join("app", dir).exist? }
@@ -137,6 +144,7 @@ module JsFromRoutes
       @client_library = "@js-from-routes/client"
       @export_if = ->(route) { route.defaults.fetch(:export, nil) }
       @file_suffix = "Api.js"
+      @filename_style = :camel
       @helper_mappings = {}
       @output_folder = root.join("app", dir, "api")
       @template_path = File.expand_path("template.js.erb", __dir__)

--- a/spec/js_from_routes/controller_routes_spec.rb
+++ b/spec/js_from_routes/controller_routes_spec.rb
@@ -1,0 +1,43 @@
+describe JsFromRoutes::ControllerRoutes do
+  # Array of controller paths to be tested
+  let(:controllers) { %w[comments settings/user_preferences video_clips some/deeply/nested/controller] }
+  # Array of expected filenames in kebab-case format for each controller
+  let(:basenames_kebab) { %w[comments-api.js settings/user-preferences-api.js video-clips-api.js some/deeply/nested/controller-api.js] }
+  # Array of expected filenames in CamelCase format for each controller
+  let(:basenames_camel) { %w[CommentsApi.js Settings/UserPreferencesApi.js VideoClipsApi.js Some/Deeply/Nested/ControllerApi.js] }
+  let(:routes) { [] }
+  let(:config) { JsFromRoutes::Configuration.new(::Rails.root || Pathname.new(Dir.pwd)) }
+
+  describe "#basename" do
+    context "when filename_style is kebab" do
+      it "returns the correct basename" do
+        config.filename_style = :kebab
+
+        controllers.each_with_index do |controller, index|
+          controller_routes = described_class.new(controller, routes, config)
+          expect(controller_routes.send(:basename)).to eq(basenames_kebab[index])
+        end
+      end
+    end
+
+    context "when filename_style is camel" do
+      it "returns the correct basename" do
+        config.filename_style = :camel
+
+        controllers.each_with_index do |controller, index|
+          controller_routes = described_class.new(controller, routes, config)
+          expect(controller_routes.send(:basename)).to eq(basenames_camel[index])
+        end
+      end
+    end
+
+    context "when filename_style is default" do
+      it "returns the correct basename" do
+        controllers.each_with_index do |controller, index|
+          controller_routes = described_class.new(controller, routes, config)
+          expect(controller_routes.send(:basename)).to eq(basenames_camel[index])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add the `filename_style` configuration option. This option allows users to configure the filename style for the generated files. The default value is `:camel`, which converts the controller name to CamelCase and appends the file suffix. Also added support for a new style, `:kebab`, which converts the controller name to kebab-case and appends the file suffix in lowercase. This provides users with more flexibility in choosing the filename convention that best suits their needs.

### Description 📖

This pull request

### Background 📜

This was happening because

### The Fix 🔨

By changing

### Screenshots 📷
